### PR TITLE
minor command fixes (/name, /uuid, /node and /dfgive)

### DIFF
--- a/src/main/java/io/github/homchom/recode/mod/commands/CommandHandler.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/CommandHandler.java
@@ -32,7 +32,7 @@ public class CommandHandler {
             new UnpackCommand(),
             new ItemdataCommand(),
             new UuidCommand(),
-            // new NameCommand(),
+            new NameCommand(),
             // new HeadsCommand(),
             new ColorsCommand(),
             new ColorCommand(),

--- a/src/main/java/io/github/homchom/recode/mod/commands/CommandHandler.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/CommandHandler.java
@@ -32,7 +32,7 @@ public class CommandHandler {
             new UnpackCommand(),
             new ItemdataCommand(),
             new UuidCommand(),
-            new NameCommand(),
+            // new NameCommand(),
             // new HeadsCommand(),
             new ColorsCommand(),
             new ColorCommand(),

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/item/GiveCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/item/GiveCommand.java
@@ -59,7 +59,7 @@ public class GiveCommand extends Command {
                                 clipboard = clipboard.substring(3);
                             }
 
-                            this.sendCommand(mc, "/dfgive " + clipboard);
+                            this.sendCommand(mc, "dfgive " + clipboard);
                             return 1;
                         })
                 )

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/other/NodeCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/other/NodeCommand.java
@@ -31,7 +31,7 @@ public class NodeCommand extends Command {
 
         for (Map.Entry<String, String> node : NODE_MAP.entrySet()) {
             cmd.then(ArgBuilder.literal(node.getKey()).executes((ctx) -> {
-                this.sendCommand(mc, "/server " + node.getValue());
+                this.sendCommand(mc, "server " + node.getValue());
                 return 1;
             }));
         }

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
@@ -1,4 +1,3 @@
-/*
 package io.github.homchom.recode.mod.commands.impl.text;
 
 import com.google.gson.*;
@@ -78,4 +77,3 @@ public class NameCommand extends Command {
         return "/name";
     }
 }
-*/

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
@@ -51,8 +51,8 @@ public class NameCommand extends Command {
                                             ).withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fullName)));
                                     this.sendMessage(mc, text);
 
-                                    if (this.isCreative(mc) && DFInfo.isOnDF() && DFInfo.currentState.getMode() == LegacyState.Mode.DEV) {
-                                        this.sendCommand(mc, "/txt " + fullName);
+                                    if (mc.player != null && mc.player.isCreative() && DFInfo.isOnDF() && DFInfo.currentState.getMode() == LegacyState.Mode.DEV) {
+                                        this.sendCommand(mc, "txt " + fullName);
                                     }
                                 } catch (IOException e) {
                                     ChatUtil.sendMessage("§cUUID §6" + uuid + "§c was not found. Please check if you misspelled it and try again.");

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
@@ -33,7 +33,7 @@ public class NameCommand extends Command {
                         .executes(ctx -> {
                             LegacyRecode.executor.submit(() -> {
                                 String uuid = ctx.getArgument("uuid", String.class);
-                                String url = "https://api.mojang.com/user/profiles/" + uuid + "/names";
+                                String url = "https://sessionserver.mojang.com/session/minecraft/profile/" + uuid;
                                 try {
                                     String NameJson = IOUtils
                                             .toString(new URL(url), StandardCharsets.UTF_8);
@@ -41,9 +41,9 @@ public class NameCommand extends Command {
                                         ChatUtil.sendMessage("Player with that UUID was not found! Please check if you misspelled it and try again.", ChatType.FAIL);
                                         return;
                                     }
-                                    List<Map> json = new Gson().fromJson(NameJson, List.class);
-                                    String nameData = json.get(json.size()-1).get("name").toString();
-                                    String fullName = nameData;
+
+                                    JsonObject json = JsonParser.parseString(NameJson).getAsJsonObject();
+                                    String fullName = json.get("name").getAsString();
 
                                     Component text = Component.literal("§eName of §6" + uuid + " §eis §b" + fullName + "§e!")
                                             .withStyle(s -> s.withHoverEvent(

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/text/NameCommand.java
@@ -1,3 +1,4 @@
+/*
 package io.github.homchom.recode.mod.commands.impl.text;
 
 import com.google.gson.*;
@@ -77,3 +78,4 @@ public class NameCommand extends Command {
         return "/name";
     }
 }
+*/

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/text/UuidCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/text/UuidCommand.java
@@ -49,7 +49,7 @@ public class UuidCommand extends Command {
                                     this.sendMessage(mc, text);
 
                                     if (mc.player != null && mc.player.isCreative() && DFInfo.isOnDF() && DFInfo.currentState.getMode() == LegacyState.Mode.DEV) {
-                                        this.sendCommand(mc, "/txt " + fullUUID);
+                                        this.sendCommand(mc, "txt " + fullUUID);
                                     }
                                 } catch (IOException e) {
                                     ChatUtil.sendMessage("§cUser §6" + username + "§c was not found.");

--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/text/UuidCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/text/UuidCommand.java
@@ -38,7 +38,7 @@ public class UuidCommand extends Command {
                                         ChatUtil.sendMessage("Player was not found!", ChatType.FAIL);
                                         return;
                                     }
-                                    JsonObject json = new JsonParser().parse(UUIDJson).getAsJsonObject();
+                                    JsonObject json = JsonParser.parseString(UUIDJson).getAsJsonObject();
                                     String uuid = json.get("id").getAsString();
                                     String fullUUID = StringUtil.fromTrimmed(uuid);
 
@@ -48,7 +48,7 @@ public class UuidCommand extends Command {
                                             ).withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fullUUID)));
                                     this.sendMessage(mc, text);
 
-                                    if (this.isCreative(mc) && DFInfo.isOnDF() && DFInfo.currentState.getMode() == LegacyState.Mode.DEV) {
+                                    if (mc.player != null && mc.player.isCreative() && DFInfo.isOnDF() && DFInfo.currentState.getMode() == LegacyState.Mode.DEV) {
                                         this.sendCommand(mc, "/txt " + fullUUID);
                                     }
                                 } catch (IOException e) {


### PR DESCRIPTION
fixed uuid command displaying an error message when the player isn't in creative.

Might want to consider not making the isCreative method send an error message when the player is not in creative.