### PR TITLE
update build action to use --no-daemon flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
       - name: build
-        run: ./gradlew build
+        run: ./gradlew build --no-daemon
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
build action will now use the `--no-daemon` flag on `gradlew`, as the process will be cleaned up at the end of the job anyways,

and the daemon running caused a permission error on windows builds that resulted in the dependencies not getting cached.