### PR TITLE
Move ItemAPI play sound to the main thread

### DIFF
--- a/src/main/java/io/github/homchom/recode/sys/networking/websocket/client/Clients.java
+++ b/src/main/java/io/github/homchom/recode/sys/networking/websocket/client/Clients.java
@@ -2,8 +2,6 @@ package io.github.homchom.recode.sys.networking.websocket.client;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.mojang.authlib.minecraft.client.MinecraftClient;
-import io.github.homchom.recode.LegacyRecode;
 import io.github.homchom.recode.sys.networking.websocket.SocketHandler;
 import io.github.homchom.recode.sys.networking.websocket.client.type.SocketItem;
 import io.github.homchom.recode.sys.renderer.ToasterUtil;

--- a/src/main/java/io/github/homchom/recode/sys/networking/websocket/client/Clients.java
+++ b/src/main/java/io/github/homchom/recode/sys/networking/websocket/client/Clients.java
@@ -2,6 +2,8 @@ package io.github.homchom.recode.sys.networking.websocket.client;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.mojang.authlib.minecraft.client.MinecraftClient;
+import io.github.homchom.recode.LegacyRecode;
 import io.github.homchom.recode.sys.networking.websocket.SocketHandler;
 import io.github.homchom.recode.sys.networking.websocket.client.type.SocketItem;
 import io.github.homchom.recode.sys.renderer.ToasterUtil;
@@ -12,6 +14,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.item.ItemStack;
 
 @Environment(EnvType.CLIENT)
 public class Clients {
@@ -38,9 +41,12 @@ public class Clients {
             }
 
             if (player.isCreative()) {
-                ItemUtil.giveCreativeItem(item.getItem(itemData), true);
-                ToasterUtil.sendToaster("Received Item!", source, SystemToast.SystemToastIds.NARRATOR_TOGGLE);
-                player.playSound(SoundEvents.ITEM_PICKUP, 200, 1);
+                final ItemStack itemStack = item.getItem(itemData);
+                Minecraft.getInstance().submit(() -> {
+                    ItemUtil.giveCreativeItem(itemStack, true);
+                    ToasterUtil.sendToaster("Received Item!", source, SystemToast.SystemToastIds.NARRATOR_TOGGLE);
+                    player.playSound(SoundEvents.ITEM_PICKUP, 200, 1);
+                });
                 result.addProperty("status", "success");
             } else {
                 throw new Exception("Player is not in creative!");


### PR DESCRIPTION
Mostly to stop C2ME from spitting out this error:
![image](https://github.com/homchom/recode/assets/28310208/dc4857f1-2511-4b6c-b640-0218c8773a7c)

Apparently to prevent a crash too?
