### PR TITLE
prevent unknown or invalid scopes spamming errors when holding

### DIFF
--- a/src/main/java/io/github/homchom/recode/mod/mixin/inventory/MHeldItemTooltip.java
+++ b/src/main/java/io/github/homchom/recode/mod/mixin/inventory/MHeldItemTooltip.java
@@ -62,11 +62,12 @@ public class MHeldItemTooltip {
             var font = Minecraft.getInstance().font;
 
             // render scope
-            if (type.equals("var") && renderVarScope) {
+            var scopeName = varData.get("scope").getAsString();
+            if (type.equals("var") && renderVarScope && scopes.containsKey(scopeName)) {
                 callbackInfo.cancel();
 
                 var name = varData.get("name").getAsString();
-                var scope = scopes.get(varData.get("scope").getAsString());
+                var scope = scopes.get(scopeName);
 
                 int x1 = (scaledWidth - font.width(Component.literal(name))) / 2;
                 int y1 = scaledHeight - 45;


### PR DESCRIPTION
I added this because of the line scope.
I can also register it in this:
```java
        scopes.put("line",
                Component.literal("LINE").withStyle((style -> style.withColor(0x55AAFF))));
```

This also covers modified items and whatever df does to scopes.