### PR TITLE
Whitespace bugfix

### DIFF
--- a/src/main/java/io/github/homchom/recode/mod/commands/impl/item/GiveCommand.java
+++ b/src/main/java/io/github/homchom/recode/mod/commands/impl/item/GiveCommand.java
@@ -61,7 +61,7 @@ public class GiveCommand extends Command {
                                 clipboard = clipboard.substring(3);
                             }
 
-                            this.sendCommand(mc, "dfgive " + clipboard);
+                            this.sendCommand(mc, "dfgive " + clipboard.trim());
                             return 1;
                         })
                 )


### PR DESCRIPTION
Hard to describe what this solves, but it simply removes trailing whitespace from /dfgive clipboard to fix issues if you copied a newline after the text. Very small bug yes, but also like an 8 character change so..