### PR TITLE
Fix styled text highlight crash

### DIFF
--- a/src/main/java/io/github/homchom/recode/ui/text/MiniMessageHighlighter.kt
+++ b/src/main/java/io/github/homchom/recode/ui/text/MiniMessageHighlighter.kt
@@ -1,7 +1,6 @@
 package io.github.homchom.recode.ui.text
 
 import io.github.homchom.recode.util.std.interpolate
-import net.kyori.adventure.text.BuildableComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.format.TextDecoration

--- a/src/main/java/io/github/homchom/recode/ui/text/MiniMessageHighlighter.kt
+++ b/src/main/java/io/github/homchom/recode/ui/text/MiniMessageHighlighter.kt
@@ -2,7 +2,6 @@ package io.github.homchom.recode.ui.text
 
 import io.github.homchom.recode.util.std.interpolate
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.minimessage.Context
 import net.kyori.adventure.text.minimessage.MiniMessage
@@ -59,7 +58,7 @@ class MiniMessageHighlighter(private val standardTags: TagResolver) {
      * - All other valid tags are treated as "literals" and colored gray.
      */
     @Suppress("UnstableApiUsage") // TODO: open issue at adventure github
-    fun highlight(input: String): ComponentLike {
+    fun highlight(input: String): Component {
         // handle the special case of inputs with <reset> parser directives
         // TODO: determine if there is a better way to do this
         val splitByResets = input.split("<reset>")
@@ -69,7 +68,7 @@ class MiniMessageHighlighter(private val standardTags: TagResolver) {
                 literal("<reset>")
             }
             append(highlight(splitByResets.last()))
-        }
+        }.asComponent()
 
         fun TagNode.input() = with(token()) { input.substring(startIndex(), endIndex()) }
         fun ValueNode.input() = with(token()) { input.substring(startIndex(), endIndex()) }

--- a/src/main/java/io/github/homchom/recode/ui/text/MiniMessageHighlighter.kt
+++ b/src/main/java/io/github/homchom/recode/ui/text/MiniMessageHighlighter.kt
@@ -1,6 +1,7 @@
 package io.github.homchom.recode.ui.text
 
 import io.github.homchom.recode.util.std.interpolate
+import net.kyori.adventure.text.BuildableComponent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.format.TextDecoration
@@ -116,7 +117,7 @@ class MiniMessageHighlighter(private val standardTags: TagResolver) {
             instance.deserializeToTree(input)
         } catch (e: Exception) {
             // https://github.com/KyoriPowered/adventure/issues/1011
-            return literalText(input, style().red())
+            return literalText(input, style().red()).asComponent()
         }
         buildNewInput(root)
         return instance.deserialize(newInput.toString())


### PR DESCRIPTION
Crash occurred when writing `<hover:show_text:'>` due to the expression being invalid and the fail-safe formatting not implementing `BuildableComponent` like the syntax highlighter expects.

resolves [Issue](https://github.com/homchom/recode/issues/77#issue-2197295954)

`MiniMessageHighlighter::highlight`'s fail-safe returned a `ComponentLike` that could not be cast to a `BuildableComponent` by `ExpressionHighlighting::highlightUncached`, crashing the game. The fix changes that fail-safe to return a `Component` (which implements `BuildableComponent`). 

I figured it's better to fix the issue in the styled-text specific code because `MiniMessageHighlighter` expects `BuildableComponents` and nothing else seems to violate that. 

Fail-safe highlighting working properly:
![image](https://github.com/homchom/recode/assets/46717680/7e75f5f2-57f1-4440-be2e-3e9196438447)
